### PR TITLE
changes on dependencies, to fix jest reference error

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "redux-persist": "5.4.0",
     "redux-thunk": "2.2.0",
     "remote-redux-devtools": "0.5.0",
-    "remote-redux-devtools-on-debugger": "^0.8.0"
+    "remote-redux-devtools-on-debugger": "^0.8.0",
+    "whatwg-fetch": "^2.0.4"
   }
 }


### PR DESCRIPTION
I have a fresh boilerplate and i'm getting "**ReferenceError: self is not defined**" running ```node node_modules/jest/bin/jest.js``` (yarn jest)

## To reproduce:

1. ```git clone -b RN git@github.com:GeekyAnts/react-native-boilerplate-redux-flow.git```
2. ```cd react-native-boilerplate-redux-flow```
3. ```yarn install```
4. ```yarn jest```

## Actual result:

```
FAIL  ............
  ● Test suite failed to run

    ReferenceError: self is not defined

      at node_modules/whatwg-fetch/dist/fetch.umd.js:8:40
      at Object.<anonymous>.support.searchParams (node_modules/whatwg-fetch/dist/fetch.umd.js:2:66)
      at Object.<anonymous> (node_modules/whatwg-fetch/dist/fetch.umd.js:5:2)
      at Object.<anonymous> (node_modules/jest-expo/src/setup.js:7:47)
```

## Expected result:

Tests pass.

## Solution:

The problem is because module **expo** (or jest-expo?) uses **isomorphic-fetch**, and maybe this boilerplate was created by expo init wich uses a older version of **whatwg-fetch**.

A [workaround](https://github.com/expo/expo-cli/issues/28#issuecomment-420196081) is to add **whatwg-fetch** version 2.0.4 to our *package.json*

```
rm -rf node_modules
npm i whatwg-fetch@2.0.4 --save
npm install
```

## Versions

* npm: 3.5.2
* yarn: 1.10.1
* node: 8.10.0
* OS: Ubuntu 18.04 (Bionic)